### PR TITLE
Remove arrow function

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,4 +4,6 @@ const imageExtensions = require('image-extensions');
 
 const exts = new Set(imageExtensions);
 
-module.exports = filepath => exts.has(path.extname(filepath).slice(1).toLowerCase());
+module.exports = function (filepath) {
+	return exts.has(path.extname(filepath).slice(1).toLowerCase());
+};


### PR DESCRIPTION
I know this library targets Node.js, but I guess the arrow function doesn't represent significant value to break the minify compatibility. 